### PR TITLE
chore(tailwind): 🎨 agregar design tokens de Figma a la config de Tail…

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,20 +7,98 @@ export default {
   theme: {
     extend: {
       colors: {
-        'identity': '#00205b',
-        'base': '#e1e2e1',
-        'action': '#00bcd4',
-        'neutral-dark': '#111827',
-        'neutral-main': '#6B7280',
-        'neutral-light': '#A7A9AC',
-        'neutral-white' : '#FDFFFF',
+        // Principals
+        identity: '#00205B',
+        base:     '#EFEFEF',
+        action:   '#00BCD4',
+        error:    '#E02828',
+
+        // Neutrals
+        neutral: {
+          'extra-dark': '#111827',
+          dark:         '#808285',
+          main:         '#A7A9AC',
+          light:        '#E1E2E1',
+          white:        '#FDFFFF',
+        },
+
+        // Status
+        status: {
+          red:    '#E02828',
+          green:  '#7FD9AE',
+          yellow: '#FFD98A',
+          blue:   '#B2E0FF',
+        },
+
+        // State
+        state: {
+          neutral: '#F2F2F2',
+          green:   '#E4F9EF',
+          yellow:  '#FFF3D6',
+          red:     '#FFE5E5',
+          blue:    '#E6F3FD',
+          purple:  '#DFD4FF',
+          dark:    '#00036A',
+        },
+
+        // Data palettes
+        'data-blue': {
+          50:  '#F4F9FF',
+          100: '#E8F0F7',
+          200: '#E6F3FD',
+          300: '#D6DDF6',
+          500: '#4380B8',
+        },
+        'data-orange': {
+          50:  '#FFF6E8',
+          100: '#FFE6B8',
+          500: '#FFAD66',
+          700: '#AD7100',
+          900: '#5C3C00',
+        },
+        'data-yellow': {
+          200: '#FFF9C4',
+        },
+        'data-green': {
+          50:  '#E4F9EF',
+          200: '#C8F5DB',
+          800: '#04724D',
+        },
+        'data-red': {
+          50:  '#FFE5E5',
+          300: '#FF9F9F',
+          600: '#CC5A5A',
+          900: '#5B0606',
+        },
+        'data-purple': {
+          100: '#DFD4FF',
+          500: '#C1ABFE',
+          900: '#00036A',
+        },
+        'data-pink': {
+          400: '#F8BBD0',
+        },
       },
       fontFamily: {
-        saira: ['Saira', 'sans-serif'],
+        saira:    ['Saira', 'sans-serif'],
         faustina: ['Faustina', 'serif'],
       },
     },
   },
-  plugins: [],
-}
+  plugins: [
+    function({ addComponents, theme }) {
+      const saira    = theme('fontFamily.saira').join(', ')
+      const faustina = theme('fontFamily.faustina').join(', ')
 
+      addComponents({
+        '.text-heading-xl':    { fontSize: '1.75rem', lineHeight: '2.5rem',   fontFamily: saira },
+        '.text-heading-l':     { fontSize: '1.375rem', lineHeight: '2rem',    fontFamily: saira },
+        '.text-title-m':       { fontSize: '1.125rem', lineHeight: '2rem',    fontFamily: saira },
+        '.text-body-m':        { fontSize: '1rem',     lineHeight: '1.5rem',  fontFamily: saira },
+        '.text-body-m-serif':  { fontSize: '1rem',     lineHeight: '1.5rem',  fontFamily: faustina },
+        '.text-body-s':        { fontSize: '0.875rem', lineHeight: '1rem',    fontFamily: saira },
+        '.text-label-caption': { fontSize: '0.75rem',  lineHeight: '0.75rem', fontFamily: saira },
+      })
+    },
+  ],
+}


### PR DESCRIPTION
…wind

- Agregar componentes de tipografía (heading-xl/l, title-m, body-m, body-s, label-caption) con font-family, font-size en rem y line-height via plugin
- Agrega paleta de colores: principals, neutrals, status, state y escalas de datos (blue, red, green, orange, yellow, purple, pink)
- Anida grupos de colores como objetos para evitar colisiones con los built-ins de Tailwind
- Referencia theme() en el plugin en lugar de hardcodear los strings de fuentes