### PR TITLE
#76 refactor(layout): ♻️ sidebar y navegación unificados + fix tokens tailwind

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,22 +1,23 @@
-import { Routes, Route, Outlet } from 'react-router-dom'
-import Buscar from './pages/Buscar/index.jsx'
-import Mapa from './pages/Mapa/index.jsx'
-import Cursada from './pages/Cursada/index.jsx'
-import Perfil from './pages/Perfil/index.jsx'
-import Inicio from './pages/Inicio/index.jsx'
-import DetalleAula from './pages/DetalleAula/index.jsx'
-import Notificaciones from './pages/Notificaciones/index.jsx'
-import Onboarding from './pages/Onboarding/index.jsx'
-import Bienvenida from './pages/Bienvenida/index.jsx'
-import Registro from './pages/Registro/index.jsx'
-import Login from './pages/Login/index.jsx'
-import AuthCallback from './pages/AuthCallback/index.jsx'
-import SeleccionCarrera from './pages/SeleccionCarrera/index.jsx'
-import Logout from './pages/Logout/index.jsx'
-import NotFound from './pages/NotFound/index.jsx'
-import Navbar from './components/Navbar/index.jsx'
-import Header from './components/Header/index.jsx'
-import PantallaCarga from './components/PantallaCarga/index.jsx'
+import { Routes, Route, Outlet } from 'react-router-dom';
+import Buscar from './pages/Buscar/index.jsx';
+import Mapa from './pages/Mapa/index.jsx';
+import Cursada from './pages/Cursada/index.jsx';
+import Perfil from './pages/Perfil/index.jsx';
+import Inicio from './pages/Inicio/index.jsx';
+import DetalleAula from './pages/DetalleAula/index.jsx';
+import Notificaciones from './pages/Notificaciones/index.jsx';
+import Onboarding from './pages/Onboarding/index.jsx';
+import Bienvenida from './pages/Bienvenida/index.jsx';
+import Registro from './pages/Registro/index.jsx';
+import Login from './pages/Login/index.jsx';
+import AuthCallback from './pages/AuthCallback/index.jsx';
+import SeleccionCarrera from './pages/SeleccionCarrera/index.jsx';
+import Logout from './pages/Logout/index.jsx';
+import NotFound from './pages/NotFound/index.jsx';
+import Navbar from './components/Navbar/index.jsx';
+import Header from './components/Header/index.jsx';
+import SidebarNav from './components/Sidebar/index.jsx';
+import PantallaCarga from './components/PantallaCarga/index.jsx';
 import {
   CareerSelectionRoute,
   GuestOnlyRoute,
@@ -25,18 +26,25 @@ import {
   RequireCareerRoute,
   RootRedirect,
   WelcomeRoute,
-} from './guards/RouteGuard.jsx'
+} from './guards/RouteGuard.jsx';
 
 function AppLayout() {
   return (
-    <div className="flex flex-col h-screen">
-      <Header />
-      <main className="flex-1 overflow-y-auto">
-        <Outlet />
-      </main>
-      <Navbar />
+    <div className="flex h-screen">
+      <SidebarNav />
+      <div className="flex flex-1 flex-col overflow-hidden">
+        <div className="lg:hidden">
+          <Header />
+        </div>
+        <main className="flex-1 overflow-y-auto">
+          <Outlet />
+        </main>
+        <div className="lg:hidden">
+          <Navbar />
+        </div>
+      </div>
     </div>
-  )
+  );
 }
 
 function App() {
@@ -44,7 +52,10 @@ function App() {
     <div className="w-full min-h-screen bg-base relative">
       <Routes>
         <Route path="/" element={<RootRedirect />} />
-        <Route path="/loading" element={<PantallaCarga mensaje="Cargando..." />} />
+        <Route
+          path="/loading"
+          element={<PantallaCarga mensaje="Cargando..." />}
+        />
         <Route path="/auth/callback" element={<AuthCallback />} />
         <Route path="/404" element={<NotFound />} />
 
@@ -80,7 +91,10 @@ function App() {
             <Route path="/mapa" element={<Mapa />} />
             <Route path="/cursada" element={<Cursada />} />
             <Route path="/perfil" element={<Perfil />} />
-            <Route path="/:edificioSlug/aulas/:aulaId" element={<DetalleAula />} />
+            <Route
+              path="/:edificioSlug/aulas/:aulaId"
+              element={<DetalleAula />}
+            />
             <Route path="/aulas/:aulaId" element={<DetalleAula />} />
           </Route>
         </Route>
@@ -88,7 +102,7 @@ function App() {
         <Route path="*" element={<NotFound />} />
       </Routes>
     </div>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/src/components/Cursada/CardSinClases/index.jsx
+++ b/src/components/Cursada/CardSinClases/index.jsx
@@ -1,13 +1,16 @@
-import { Calendar } from 'lucide-react'
+import { CalendarX } from 'lucide-react';
 
-export default function CardSinClases() {
+export default function CardSinClases({
+  titulo = 'Sin clases',
+  descripcion = 'No tenés materias guardadas para este día',
+}) {
   return (
-    <div className="bg-base flex flex-col items-center justify-center gap-2 p-10 rounded-[20px] w-full">
-      <Calendar size={56} className="text-neutral-light" strokeWidth={1.5} />
-      <p className="font-saira font-semibold text-[22px] text-neutral-extra-dark mt-1">Sin clases</p>
-      <p className="font-saira text-sm text-neutral-main text-center">
-        No tenés materias guardadas para este día
-      </p>
+    <div className="flex w-full flex-col items-center justify-center gap-1 rounded-[30px] bg-neutral-light py-7">
+      <div className="flex h-[70px] w-[70px] items-center justify-center rounded-full bg-neutral-dark">
+        <CalendarX size={30} className="text-base" strokeWidth={2} />
+      </div>
+      <p className="text-heading-l text-neutral-extra-dark">{titulo}</p>
+      <p className="text-body-s text-center text-neutral-dark">{descripcion}</p>
     </div>
-  )
+  );
 }

--- a/src/components/Header/ProfileOverlay/index.jsx
+++ b/src/components/Header/ProfileOverlay/index.jsx
@@ -1,207 +1,186 @@
-import { useEffect } from "react";
+import { useEffect } from 'react';
 import {
-    ChevronRight,
-    Flame,
-    LogOut,
-    Star,
-    TableProperties,
-    User,
-    X,
-} from "lucide-react";
-import { obtenerInicialesNombre } from "../../../utils/avatar";
+  ChevronRight,
+  LogOut,
+  Star,
+  TableProperties,
+  User,
+  X,
+} from 'lucide-react';
+import { obtenerInicialesNombre } from '../../../utils/avatar';
 
 function OverlayAction({
-    icon,
-    title,
-    description,
-    onClick,
-    accentClass = "bg-neutral-extra-dark text-neutral-white",
-    textClass = "text-neutral-white",
-    descriptionClass = "text-neutral-dark",
-    iconStrokeClass = "",
-    chevron = true,
-    disabled = false,
+  icon,
+  title,
+  description,
+  onClick,
+  accentClass = 'bg-neutral-extra-dark text-neutral-white',
+  textClass = 'text-neutral-white',
+  descriptionClass = 'text-neutral-dark',
+  iconStrokeClass = '',
+  chevron = true,
+  disabled = false,
 }) {
-    const IconComponent = icon;
+  const IconComponent = icon;
 
-    const content = (
-        <>
-            <div
-                className={`flex h-14 w-14 shrink-0 items-center justify-center rounded-[10px] ${accentClass}`}
-            >
-                <IconComponent size={24} className={iconStrokeClass} />
-            </div>
-            <div className="flex min-w-0 flex-1 flex-col gap-1">
-                <p className={`font-saira text-[22px] font-semibold leading-8 ${textClass}`}>
-                    {title}
-                </p>
-                {description ? (
-                    <p className={`font-saira text-sm leading-4 ${descriptionClass}`}>
-                        {description}
-                    </p>
-                ) : null}
-            </div>
-            {chevron ? (
-                <ChevronRight size={22} className="shrink-0 text-neutral-white" />
-            ) : null}
-        </>
-    );
-
-    if (disabled) {
-        return (
-            <div className="flex w-full items-center gap-3 py-4">
-                {content}
-            </div>
-        );
-    }
-
-    return (
-        <button
-            type="button"
-            onClick={onClick}
-            className="flex w-full items-center gap-3 py-4 text-left"
+  const content = (
+    <>
+      <div
+        className={`flex h-14 w-14 shrink-0 items-center justify-center rounded-[10px] ${accentClass}`}
+      >
+        <IconComponent size={24} className={iconStrokeClass} />
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <p
+          className={`font-saira text-[22px] font-semibold leading-8 ${textClass}`}
         >
-            {content}
-        </button>
-    );
+          {title}
+        </p>
+        {description ? (
+          <p className={`font-saira text-sm leading-4 ${descriptionClass}`}>
+            {description}
+          </p>
+        ) : null}
+      </div>
+      {chevron ? (
+        <ChevronRight size={22} className="shrink-0 text-neutral-white" />
+      ) : null}
+    </>
+  );
+
+  if (disabled) {
+    return <div className="flex w-full items-center gap-3 py-4">{content}</div>;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex w-full items-center gap-3 py-4 text-left"
+    >
+      {content}
+    </button>
+  );
 }
 
 export default function ProfileOverlay({
-    open,
-    avatarUrl,
-    nombre,
-    carrera,
-    nivel,
-    estadisticas,
-    onClose,
-    onGoPerfil,
-    onLogout,
+  open,
+  avatarUrl,
+  nombre,
+  carrera,
+  nivel,
+  onClose,
+  onGoPerfil,
+  onLogout,
 }) {
-    useEffect(() => {
-        if (!open) return;
+  useEffect(() => {
+    if (!open) return;
 
-        const handleEscape = (event) => {
-            if (event.key === "Escape") {
-                onClose();
-            }
-        };
+    const handleEscape = (event) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
 
-        window.addEventListener("keydown", handleEscape);
-        return () => {
-            window.removeEventListener("keydown", handleEscape);
-        };
-    }, [open, onClose]);
+    window.addEventListener('keydown', handleEscape);
+    return () => {
+      window.removeEventListener('keydown', handleEscape);
+    };
+  }, [open, onClose]);
 
-    if (!open) return null;
+  if (!open) return null;
 
-    const iniciales = obtenerInicialesNombre(nombre);
-    const chipNivel =
-        nivel?.nombre && Number.isFinite(nivel?.xpActual)
-            ? `${nivel.nombre} - ${nivel.xpActual} XP`
-            : null;
-    const chipRacha =
-        estadisticas?.racha && estadisticas.racha > 0
-            ? `${estadisticas.racha} días`
-            : null;
-
-    return (
-        <div
-            className="fixed inset-0 z-[60] bg-identity"
-            role="dialog"
-            aria-modal="true"
-            aria-label="Menú de perfil"
-        >
-            <div className="relative flex min-h-screen flex-col px-8 pb-8 pt-5">
-                <div className="absolute right-4 top-4">
-                    <button
-                        type="button"
-                        onClick={onClose}
-                        className="flex h-8 w-8 items-center justify-center rounded-full text-base"
-                        aria-label="Cerrar menú"
-                    >
-                        <X size={20} />
-                    </button>
-                </div>
-
-                <div className="flex flex-col items-center px-4 pb-4 pt-16">
-                    {avatarUrl ? (
-                        <img
-                            src={avatarUrl}
-                            alt="Perfil"
-                            className="h-20 w-20 rounded-full object-cover"
-                            referrerPolicy="no-referrer"
-                        />
-                    ) : (
-                        <div className="flex h-20 w-20 items-center justify-center rounded-full bg-neutral-main">
-                            <span className="font-saira text-2xl font-bold text-neutral-extra-dark">
-                                {iniciales}
-                            </span>
-                        </div>
-                    )}
-
-                    <h2 className="mt-0.5 font-saira text-[28px] font-bold leading-10 text-base">
-                        {nombre}
-                    </h2>
-
-                    {carrera ? (
-                        <p className="mt-0.5 font-saira text-sm leading-4 text-base text-center">
-                            {carrera}
-                        </p>
-                    ) : null}
-
-                    <div className="mt-3 flex flex-wrap items-center justify-center gap-3">
-                        {chipNivel ? (
-                            <div className="flex items-center gap-2 rounded-full bg-action px-3 py-2">
-                                <Star
-                                    size={16}
-                                    className="text-neutral-extra-dark"
-                                />
-                                <span className="font-saira text-sm leading-4 text-neutral-extra-dark">
-                                    {chipNivel}
-                                </span>
-                            </div>
-                        ) : null}
-
-                        {chipRacha ? (
-                            <div className="flex items-center gap-1 rounded-full bg-data-pink-400 px-3 py-2">
-                                <Flame size={16} className="text-error" />
-                                <span className="font-saira text-sm leading-4 text-error">
-                                    {chipRacha}
-                                </span>
-                            </div>
-                        ) : null}
-                    </div>
-                </div>
-
-                <div className="mt-2 flex flex-col gap-1 border-t border-neutral-dark/60 pt-1">
-                    <OverlayAction
-                        icon={User}
-                        title="Perfil"
-                        description="Estadísticas e insignias"
-                        onClick={onGoPerfil}
-                    />
-                    <OverlayAction
-                        icon={TableProperties}
-                        title="Editar información"
-                        description="Nombre, carrera, foto"
-                        disabled
-                    />
-                </div>
-
-                <div className="mt-2 border-t border-neutral-dark/60 pt-3">
-                    <OverlayAction
-                        icon={LogOut}
-                        title="Cerrar sesión"
-                        description=""
-                        onClick={onLogout}
-                        accentClass="bg-data-red-900 text-error"
-                        textClass="text-error"
-                        descriptionClass="text-error"
-                        iconStrokeClass="text-error"
-                        chevron={false}
-                    />
-                </div>
-            </div>
+  const iniciales = obtenerInicialesNombre(nombre);
+  const chipNivel =
+    nivel?.nombre && Number.isFinite(nivel?.xpActual)
+      ? `${nivel.nombre} - ${nivel.xpActual} XP`
+      : null;
+  return (
+    <div
+      className="fixed inset-0 z-[60] bg-identity"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Menú de perfil"
+    >
+      <div className="relative flex min-h-screen flex-col px-8 pb-8 pt-5">
+        <div className="absolute right-4 top-4">
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex h-8 w-8 items-center justify-center rounded-full text-base"
+            aria-label="Cerrar menú"
+          >
+            <X size={20} />
+          </button>
         </div>
-    );
+
+        <div className="flex flex-col items-center px-4 pb-4 pt-16">
+          {avatarUrl ? (
+            <img
+              src={avatarUrl}
+              alt="Perfil"
+              className="h-20 w-20 rounded-full object-cover"
+              referrerPolicy="no-referrer"
+            />
+          ) : (
+            <div className="flex h-20 w-20 items-center justify-center rounded-full bg-neutral-main">
+              <span className="font-saira text-2xl font-bold text-neutral-extra-dark">
+                {iniciales}
+              </span>
+            </div>
+          )}
+
+          <h2 className="mt-0.5 font-saira text-[28px] font-bold leading-10 text-base">
+            {nombre}
+          </h2>
+
+          {carrera ? (
+            <p className="mt-0.5 font-saira text-sm leading-4 text-base text-center">
+              {carrera}
+            </p>
+          ) : null}
+
+          <div className="mt-3 flex flex-wrap items-center justify-center gap-3">
+            {chipNivel ? (
+              <div className="flex items-center gap-2 rounded-full bg-action px-3 py-2">
+                <Star size={16} className="text-neutral-extra-dark" />
+                <span className="font-saira text-sm leading-4 text-neutral-extra-dark">
+                  {chipNivel}
+                </span>
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="mt-2 flex flex-col gap-1 border-t border-neutral-dark/60 pt-1">
+          <OverlayAction
+            icon={User}
+            title="Perfil"
+            description="Estadísticas e insignias"
+            onClick={onGoPerfil}
+          />
+          <OverlayAction
+            icon={TableProperties}
+            title="Editar información"
+            description="Nombre, carrera, foto"
+            disabled
+          />
+        </div>
+
+        <div className="mt-2 border-t border-neutral-dark/60 pt-3">
+          <OverlayAction
+            icon={LogOut}
+            title="Cerrar sesión"
+            description=""
+            onClick={onLogout}
+            accentClass="bg-data-red-900 text-error"
+            textClass="text-error"
+            descriptionClass="text-error"
+            iconStrokeClass="text-error"
+            chevron={false}
+          />
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -1,147 +1,112 @@
-import { useEffect, useState } from 'react'
-import { useLocation, useNavigate } from 'react-router-dom'
-import { BellDot, Bolt, Flame } from 'lucide-react'
-import { useAuth } from '../../context/AuthContext'
-import { getEstadisticas } from '../../services/perfil'
-import { obtenerInicialesNombre } from '../../utils/avatar.js'
-import logotipoWhite from '../../assets/logotipo_white.svg'
-import ProfileOverlay from './ProfileOverlay/index.jsx'
-import usePerfilResumen from '../../hooks/usePerfilResumen'
+import { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { BellDot, Bolt } from 'lucide-react';
+import { useAuth } from '../../context/AuthContext';
+import { obtenerInicialesNombre } from '../../utils/avatar.js';
+import logotipoWhite from '../../assets/logotipo_white.svg';
+import ProfileOverlay from './ProfileOverlay/index.jsx';
+import usePerfilResumen from '../../hooks/usePerfilResumen';
 
 function AvatarButton({ avatarUrl, nombre, onClick, className = 'h-8 w-8' }) {
-    return (
-        <button
-            type="button"
-            onClick={onClick}
-            className={`flex items-center justify-center rounded-full ${className}`}
-            aria-label="Abrir menú de perfil"
-        >
-            {avatarUrl ? (
-                <img
-                    src={avatarUrl}
-                    alt="Perfil"
-                    className="h-full w-full rounded-full object-cover"
-                    referrerPolicy="no-referrer"
-                />
-            ) : (
-                <div className="flex h-full w-full items-center justify-center rounded-full bg-neutral-main">
-                    <span className="font-saira text-xs font-bold text-neutral-extra-dark">
-                        {obtenerInicialesNombre(nombre)}
-                    </span>
-                </div>
-            )}
-        </button>
-    );
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex items-center justify-center rounded-full ${className}`}
+      aria-label="Abrir menú de perfil"
+    >
+      {avatarUrl ? (
+        <img
+          src={avatarUrl}
+          alt="Perfil"
+          className="h-full w-full rounded-full object-cover"
+          referrerPolicy="no-referrer"
+        />
+      ) : (
+        <div className="flex h-full w-full items-center justify-center rounded-full bg-neutral-main">
+          <span className="font-saira text-xs font-bold text-neutral-extra-dark">
+            {obtenerInicialesNombre(nombre)}
+          </span>
+        </div>
+      )}
+    </button>
+  );
 }
 
 export default function Header() {
-    const { user } = useAuth();
-    const { pathname } = useLocation();
-    const navigate = useNavigate();
-    const avatarUrl = user?.user_metadata?.avatar_url;
-    const nombre =
-        user?.user_metadata?.full_name ??
-        user?.user_metadata?.name ??
-        user?.email ??
-        "Usuario";
-    const esPerfil = pathname === "/perfil";
-    const [menuAbierto, setMenuAbierto] = useState(false);
-    const [racha, setRacha] = useState(0);
-    const { carrera, nivel, estadisticas } = usePerfilResumen(user?.id, menuAbierto);
+  const { user } = useAuth();
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+  const avatarUrl = user?.user_metadata?.avatar_url;
+  const nombre =
+    user?.user_metadata?.full_name ??
+    user?.user_metadata?.name ??
+    user?.email ??
+    'Usuario';
+  const esPerfil = pathname === '/perfil';
+  const [menuAbierto, setMenuAbierto] = useState(false);
+  const { carrera, nivel } = usePerfilResumen(user?.id, menuAbierto);
 
-    const abrirMenu = () => setMenuAbierto(true);
-    const cerrarMenu = () => setMenuAbierto(false);
-    const irAPerfil = () => {
-        setMenuAbierto(false);
-        navigate('/perfil');
-    };
-    const irALogout = () => {
-        setMenuAbierto(false);
-        navigate('/logout');
-    };
-    const irANotificaciones = () => navigate('/notificaciones');
+  const abrirMenu = () => setMenuAbierto(true);
+  const cerrarMenu = () => setMenuAbierto(false);
+  const irAPerfil = () => {
+    setMenuAbierto(false);
+    navigate('/perfil');
+  };
+  const irALogout = () => {
+    setMenuAbierto(false);
+    navigate('/logout');
+  };
+  const irANotificaciones = () => navigate('/notificaciones');
 
-    useEffect(() => {
-        if (!user || esPerfil) return;
+  const header = !esPerfil ? (
+    <header className="bg-identity px-4 h-16 flex items-center justify-between gap-3">
+      <img src={logotipoWhite} alt="GEOUNSAM" className="h-5 shrink-0" />
 
-        let mounted = true;
+      <div className="flex items-center gap-3 ml-auto">
+        <button
+          type="button"
+          onClick={irANotificaciones}
+          className="text-neutral-white"
+          aria-label="Notificaciones"
+        >
+          <BellDot size={22} />
+        </button>
 
-        getEstadisticas(user.id)
-            .then((estadisticas) => {
-                if (mounted) setRacha(estadisticas?.racha ?? 0);
-            })
-            .catch((error) => {
-                console.error(error);
-                if (mounted) setRacha(0);
-            });
+        <AvatarButton
+          avatarUrl={avatarUrl}
+          nombre={nombre}
+          onClick={abrirMenu}
+        />
+      </div>
+    </header>
+  ) : (
+    <header className="bg-identity px-5 h-16 flex items-center justify-between relative">
+      <div className="w-8 h-8" />
+      <img src={logotipoWhite} alt="GEOUNSAM" className="h-5" />
+      <button
+        type="button"
+        onClick={abrirMenu}
+        aria-label="Abrir menú de perfil"
+      >
+        <Bolt size={24} className="text-neutral-main" />
+      </button>
+    </header>
+  );
 
-        return () => {
-            mounted = false;
-        };
-    }, [esPerfil, user]);
-
-    const header = !esPerfil ? (
-            <header className="bg-identity px-4 h-16 flex items-center justify-between gap-3">
-                <img
-                    src={logotipoWhite}
-                    alt="GEOUNSAM"
-                    className="h-5 shrink-0"
-                />
-
-                <div className="flex items-center gap-3 ml-auto">
-                    {racha > 0 ? (
-                        <div className="hidden min-[360px]:flex items-center gap-1 rounded-full bg-data-pink-400 px-3 py-2">
-                            <Flame size={14} className="text-error" />
-                            <span className="font-saira text-sm leading-4 text-error">
-                                {racha} días
-                            </span>
-                        </div>
-                    ) : null}
-
-                    <button
-                        type="button"
-                        onClick={irANotificaciones}
-                        className="text-neutral-white"
-                        aria-label="Notificaciones"
-                    >
-                        <BellDot size={22} />
-                    </button>
-
-                    <AvatarButton
-                        avatarUrl={avatarUrl}
-                        nombre={nombre}
-                        onClick={abrirMenu}
-                    />
-                </div>
-            </header>
-    ) : (
-        <header className="bg-identity px-5 h-16 flex items-center justify-between relative">
-            <div className="w-8 h-8" />
-            <img src={logotipoWhite} alt="GEOUNSAM" className="h-5" />
-            <button
-                type="button"
-                onClick={abrirMenu}
-                aria-label="Abrir menú de perfil"
-            >
-                <Bolt size={24} className="text-neutral-main" />
-            </button>
-        </header>
-    );
-
-    return (
-        <>
-            {header}
-            <ProfileOverlay
-                open={menuAbierto}
-                avatarUrl={avatarUrl}
-                nombre={nombre}
-                carrera={carrera}
-                nivel={nivel}
-                estadisticas={estadisticas}
-                onClose={cerrarMenu}
-                onGoPerfil={irAPerfil}
-                onLogout={irALogout}
-            />
-        </>
-    );
+  return (
+    <>
+      {header}
+      <ProfileOverlay
+        open={menuAbierto}
+        avatarUrl={avatarUrl}
+        nombre={nombre}
+        carrera={carrera}
+        nivel={nivel}
+        onClose={cerrarMenu}
+        onGoPerfil={irAPerfil}
+        onLogout={irALogout}
+      />
+    </>
+  );
 }

--- a/src/components/Inicio/ActionCard/index.jsx
+++ b/src/components/Inicio/ActionCard/index.jsx
@@ -1,21 +1,17 @@
 export default function ActionCard({ icon, titulo, detalle, onClick }) {
-    const Icon = icon;
+  const Icon = icon;
 
-    return (
-        <button
-            type="button"
-            onClick={onClick}
-            className="flex min-h-[120px] flex-1 flex-col items-start justify-center rounded-[30px] bg-action px-6 py-4 text-left text-neutral-extra-dark"
-        >
-            <div className="mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-base">
-                <Icon size={20} />
-            </div>
-            <span className="font-saira text-lg font-semibold leading-8">
-                {titulo}
-            </span>
-            <span className="font-saira text-xs font-medium leading-3">
-                {detalle}
-            </span>
-        </button>
-    );
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex min-h-[120px] flex-1 flex-col items-start justify-center gap-1 rounded-[30px] bg-action px-6 py-4 text-left text-neutral-extra-dark"
+    >
+      <div className="flex h-9 w-9 items-center justify-center rounded-full bg-base">
+        <Icon size={18} />
+      </div>
+      <span className="text-title-m">{titulo}</span>
+      <span className="text-label-caption">{detalle}</span>
+    </button>
+  );
 }

--- a/src/components/Inicio/SectionTitle/index.jsx
+++ b/src/components/Inicio/SectionTitle/index.jsx
@@ -1,7 +1,3 @@
 export default function SectionTitle({ children }) {
-    return (
-        <h2 className="font-saira text-lg font-semibold leading-8 text-identity">
-            {children}
-        </h2>
-    );
+  return <h2 className="text-title-m text-identity">{children}</h2>;
 }

--- a/src/components/Navbar/index.jsx
+++ b/src/components/Navbar/index.jsx
@@ -1,53 +1,25 @@
-import { NavLink } from "react-router-dom";
-import { House, Search, MapPin, Calendar, User } from "lucide-react";
-
-const tabs = [
-    {
-        name: "Inicio",
-        path: "/inicio",
-        icon: <House size={24} />,
-    },
-    {
-        name: "Buscar",
-        path: "/buscar",
-        icon: <Search size={24} />,
-    },
-    {
-        name: "Mapa",
-        path: "/mapa",
-        icon: <MapPin size={24} />,
-    },
-    {
-        name: "Cursada",
-        path: "/cursada",
-        icon: <Calendar size={24} />,
-    },
-    {
-        name: "Perfil",
-        path: "/perfil",
-        icon: <User size={24} />,
-    },
-];
+import { NavLink } from 'react-router-dom';
+import { NAV_ITEMS_MOBILE } from '../../config/navItems';
 
 export default function Navbar() {
-    return (
-        <nav className="fixed bottom-0 left-0 w-full bg-identity px-4 py-3">
-            <div className="flex items-center justify-between px-3">
-                {tabs.map((tab) => (
-                    <NavLink
-                        key={tab.path}
-                        to={tab.path}
-                        className={({ isActive }) =>
-                            `flex flex-col items-center gap-1 font-saira text-sm ${
-                                isActive ? "text-white" : "text-neutral-main"
-                            }`
-                        }
-                    >
-                        {tab.icon}
-                        {tab.name}
-                    </NavLink>
-                ))}
-            </div>
-        </nav>
-    );
+  return (
+    <nav className="fixed bottom-0 left-0 w-full bg-identity px-4 py-3">
+      <div className="flex items-center justify-between px-3">
+        {NAV_ITEMS_MOBILE.map(({ shortLabel, path, icon: Icon }) => (
+          <NavLink
+            key={path}
+            to={path}
+            className={({ isActive }) =>
+              `flex flex-col items-center gap-1 text-label-caption ${
+                isActive ? 'text-white' : 'text-neutral-main'
+              }`
+            }
+          >
+            <Icon size={24} />
+            {shortLabel}
+          </NavLink>
+        ))}
+      </div>
+    </nav>
+  );
 }

--- a/src/components/PantallaCarga/index.jsx
+++ b/src/components/PantallaCarga/index.jsx
@@ -1,17 +1,22 @@
-import samuLoading from "../../assets/samu_loading.png";
+import samuLoading from '../../assets/samu_loading.png';
 
-export default function PantallaCarga({ mensaje = "Cargando...", compact = false }) {
-    return (
-        <div className={`${compact ? "flex min-h-full w-full flex-1 items-center justify-center bg-base px-6 py-10" : "flex min-h-screen w-full items-center justify-center bg-base px-6"}`}>
-            <div className="flex flex-col items-center gap-10 text-center">
-                <img
-                    src={samuLoading}
-                    alt="Samu cargando"
-                    className="h-[280px] w-auto object-contain"
-                />
-                <div className="h-9 w-9 animate-spin rounded-full border-4 border-neutral/30 border-t-identity" />
-                <p className="font-saira text-[28px] font-bold leading-10 text-identity">{mensaje}</p>
-            </div>
-        </div>
-    );
+export default function PantallaCarga({
+  mensaje = 'Cargando...',
+  compact = false,
+}) {
+  return (
+    <div
+      className={`${compact ? 'flex min-h-full w-full flex-1 items-center justify-center bg-base px-6 py-10' : 'flex min-h-screen w-full items-center justify-center bg-base px-6'}`}
+    >
+      <div className="flex flex-col items-center gap-10 text-center">
+        <img
+          src={samuLoading}
+          alt="Samu cargando"
+          className="h-[280px] w-auto object-contain"
+        />
+        <div className="h-9 w-9 animate-spin rounded-full border-4 border-neutral/30 border-t-identity" />
+        <p className="text-heading-xl text-identity">{mensaje}</p>
+      </div>
+    </div>
+  );
 }

--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -1,0 +1,168 @@
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate, NavLink } from 'react-router-dom';
+import { MoreHorizontal, User, TableProperties, LogOut } from 'lucide-react';
+import { useAuth } from '../../context/AuthContext';
+import { obtenerInicialesNombre } from '../../utils/avatar';
+import logotipoWhite from '../../assets/logotipo_white.svg';
+import { NAV_ITEMS } from '../../config/navItems';
+
+function SidebarPopover({ onGoPerfil, onLogout, onClose }) {
+  const ref = useRef(null);
+
+  useEffect(() => {
+    function handleClick(e) {
+      if (ref.current && !ref.current.contains(e.target)) onClose();
+    }
+    function handleEsc(e) {
+      if (e.key === 'Escape') onClose();
+    }
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleEsc);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleEsc);
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      ref={ref}
+      className="absolute bottom-full left-3 right-3 mb-2 overflow-hidden rounded-2xl border border-white/10 bg-identity shadow-xl"
+      role="menu"
+    >
+      {/* Perfil */}
+      <button
+        type="button"
+        onClick={onGoPerfil}
+        className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-white/10"
+        role="menuitem"
+      >
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white/10">
+          <User size={16} className="text-white" />
+        </div>
+        <div>
+          <p className="text-body-m text-white">Perfil</p>
+        </div>
+      </button>
+
+      {/* Editar info — disabled */}
+      <div className="flex w-full items-center gap-3 px-4 py-3 opacity-40">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white/10">
+          <TableProperties size={16} className="text-white" />
+        </div>
+        <div>
+          <p className="text-body-m text-white">Editar información</p>
+        </div>
+      </div>
+
+      {/* Separador */}
+      <div className="mx-4 border-t border-white/10" />
+
+      {/* Cerrar sesión */}
+      <button
+        type="button"
+        onClick={onLogout}
+        className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-white/10"
+        role="menuitem"
+      >
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-data-red-900/60">
+          <LogOut size={16} className="text-error" />
+        </div>
+        <p className="text-body-m text-error">Cerrar sesión</p>
+      </button>
+    </div>
+  );
+}
+
+export default function SidebarNav() {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const [menuAbierto, setMenuAbierto] = useState(false);
+
+  const avatarUrl = user?.user_metadata?.avatar_url;
+  const nombre =
+    user?.user_metadata?.full_name ??
+    user?.user_metadata?.name ??
+    user?.email ??
+    'Usuario';
+
+  const irAPerfil = () => {
+    setMenuAbierto(false);
+    navigate('/perfil');
+  };
+  const irALogout = () => {
+    setMenuAbierto(false);
+    navigate('/logout');
+  };
+
+  return (
+    <aside className="hidden lg:flex w-[220px] shrink-0 flex-col bg-identity">
+      <div className="flex h-16 items-center border-b border-white/10 px-6">
+        <img src={logotipoWhite} alt="GEOUNSAM" className="h-5" />
+      </div>
+
+      <nav className="flex flex-1 flex-col gap-1 px-3 py-4">
+        {NAV_ITEMS.map(({ label, path, icon: Icon }) => (
+          <NavLink
+            key={path}
+            to={path}
+            className={({ isActive }) =>
+              `flex items-center gap-3 rounded-xl px-3 py-3 text-body-s font-medium transition-colors ${
+                isActive
+                  ? 'bg-white/15 text-white'
+                  : 'text-neutral-main hover:bg-white/10 hover:text-white'
+              }`
+            }
+          >
+            <Icon size={20} />
+            {label}
+          </NavLink>
+        ))}
+      </nav>
+
+      {/* Perfil en el pie — posición relativa para anclar el popover */}
+      <div className="relative border-t border-white/10 px-3 py-4">
+        {menuAbierto && (
+          <SidebarPopover
+            onGoPerfil={irAPerfil}
+            onLogout={irALogout}
+            onClose={() => setMenuAbierto(false)}
+          />
+        )}
+
+        <button
+          type="button"
+          onClick={() => setMenuAbierto((v) => !v)}
+          className="flex w-full items-center gap-3 rounded-xl px-3 py-3 text-left transition-colors hover:bg-white/10"
+        >
+          {/* Avatar */}
+          <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
+            {avatarUrl ? (
+              <img
+                src={avatarUrl}
+                alt="Perfil"
+                className="h-full w-full object-cover"
+                referrerPolicy="no-referrer"
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center bg-neutral-main">
+                <span className="font-saira text-xs font-bold text-neutral-extra-dark">
+                  {obtenerInicialesNombre(nombre)}
+                </span>
+              </div>
+            )}
+          </div>
+
+          <span className="min-w-0 flex-1 truncate text-body-s font-medium text-white">
+            {nombre}
+          </span>
+
+          <MoreHorizontal
+            size={16}
+            className={`shrink-0 transition-colors ${menuAbierto ? 'text-white' : 'text-neutral-main'}`}
+          />
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/Tip/index.jsx
+++ b/src/components/Tip/index.jsx
@@ -1,108 +1,134 @@
-import { ArrowRight, Info } from "lucide-react";
-import { Link } from "react-router-dom";
+import { ArrowRight, Info } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+const VARIANTS = {
+  info: {
+    container: 'border-2 border-action bg-state-blue p-4',
+    icon: 'text-action',
+    actionStyle: 'text',
+  },
+  tip: {
+    container: 'bg-state-purple px-3 py-2',
+    icon: 'text-state-dark',
+    actionStyle: 'text',
+  },
+  success: {
+    container: 'bg-data-green-200 px-3 py-2',
+    icon: 'text-data-green-800',
+    actionStyle: 'text',
+  },
+  warning: {
+    container: 'border-2 border-data-orange-500 bg-state-yellow p-4',
+    icon: 'text-data-orange-500',
+    actionStyle: 'pill',
+  },
+  error: {
+    container: 'border border-error bg-state-red px-4 py-3',
+    icon: 'text-error',
+    actionStyle: 'text',
+  },
+};
+
+const TEXT_ACTION_CLASS =
+  'inline-flex items-center gap-1 text-body-m-serif text-action';
+const PILL_ACTION_CLASS =
+  'inline-flex items-center gap-1 rounded-[10px] bg-data-orange-500 px-3 py-1.5 text-label-caption text-neutral-extra-dark';
 
 export default function Tip({
-    children,
-    icon,
-    title,
-    description,
-    actionLabel,
-    actionTo,
-    onAction,
-    actionIcon: ActionIcon = ArrowRight,
+  children,
+  icon,
+  title,
+  description,
+  actionLabel,
+  actionTo,
+  onAction,
+  actionIcon: ActionIcon = ArrowRight,
+  variant = 'info',
 }) {
-    const IconComponent = icon ?? Info;
-    const hasStructuredContent = title || description || actionLabel;
+  const IconComponent = icon ?? Info;
+  const hasStructuredContent = title || description || actionLabel;
+  const styles = VARIANTS[variant] ?? VARIANTS.info;
+  const actionClassName =
+    styles.actionStyle === 'pill' ? PILL_ACTION_CLASS : TEXT_ACTION_CLASS;
 
-    const actionClassName = "inline-flex items-center gap-1 font-faustina text-[16px] font-medium leading-6 text-action visited:text-action active:text-action";
+  const renderAction = () => {
+    if (!actionLabel) return null;
 
-    const renderAction = () => {
-        if (!actionLabel) return null;
+    const content = (
+      <>
+        {actionLabel}
+        {ActionIcon ? (
+          <ActionIcon size={16} strokeWidth={2} aria-hidden="true" />
+        ) : null}
+      </>
+    );
 
-        const content = (
-            <>
-                {actionLabel}
-                {ActionIcon ? (
-                    <ActionIcon size={16} strokeWidth={2} aria-hidden="true" />
-                ) : null}
-            </>
-        );
+    const wrapClass = styles.actionStyle === 'pill' ? 'mt-1' : 'mt-2';
 
-        if (actionTo) {
-            if (/^https?:\/\//i.test(actionTo)) {
-                const target = new URL(actionTo);
-                const sameOrigin = target.origin === window.location.origin;
-
-                if (sameOrigin) {
-                    return (
-                        <div className="mt-2">
-                            <Link
-                                to={`${target.pathname}${target.search}${target.hash}`}
-                                className={actionClassName}
-                            >
-                                {content}
-                            </Link>
-                        </div>
-                    );
-                }
-
-                return (
-                    <div className="mt-2">
-                        <a href={actionTo} className={actionClassName}>
-                            {content}
-                        </a>
-                    </div>
-                );
-            }
-
-            return (
-                <div className="mt-2">
-                    <Link to={actionTo} className={actionClassName}>
-                        {content}
-                    </Link>
-                </div>
-            );
-        }
+    if (actionTo) {
+      if (/^https?:\/\//i.test(actionTo)) {
+        const target = new URL(actionTo);
+        const sameOrigin = target.origin === window.location.origin;
 
         return (
-            <div className="mt-2">
-                <button
-                    type="button"
-                    onClick={onAction}
-                    className={actionClassName}
-                >
-                    {content}
-                </button>
-            </div>
+          <div className={wrapClass}>
+            {sameOrigin ? (
+              <Link
+                to={`${target.pathname}${target.search}${target.hash}`}
+                className={actionClassName}
+              >
+                {content}
+              </Link>
+            ) : (
+              <a href={actionTo} className={actionClassName}>
+                {content}
+              </a>
+            )}
+          </div>
         );
-    };
+      }
+
+      return (
+        <div className={wrapClass}>
+          <Link to={actionTo} className={actionClassName}>
+            {content}
+          </Link>
+        </div>
+      );
+    }
 
     return (
-        <section className="flex items-start gap-3 rounded-[20px] border-2 border-action bg-state-blue px-4 py-4 text-neutral-extra-dark">
-            <IconComponent
-                size={20}
-                className="mt-0.5 shrink-0 text-action"
-            />
-            {hasStructuredContent ? (
-                <div className="min-w-0 flex-1">
-                    {title ? (
-                        <p className="font-saira text-base leading-6 text-neutral-extra-dark">
-                            {title}
-                        </p>
-                    ) : null}
-                    {description ? (
-                        <p className="font-saira text-sm leading-4 text-neutral-extra-dark">
-                            {description}
-                        </p>
-                    ) : null}
-                    {children}
-                    {renderAction()}
-                </div>
-            ) : (
-                <p className="font-saira text-base leading-6 text-neutral-extra-dark">
-                    {children}
-                </p>
-            )}
-        </section>
+      <div className={wrapClass}>
+        <button type="button" onClick={onAction} className={actionClassName}>
+          {content}
+        </button>
+      </div>
     );
+  };
+
+  return (
+    <section
+      className={`flex items-start gap-2 rounded-[20px] text-neutral-extra-dark ${styles.container}`}
+    >
+      <IconComponent
+        size={20}
+        className={`mt-0.5 shrink-0 ${styles.icon}`}
+        strokeWidth={2}
+      />
+      {hasStructuredContent ? (
+        <div className="min-w-0 flex-1">
+          {title ? (
+            <p className="text-body-m text-neutral-extra-dark">{title}</p>
+          ) : null}
+          {description ? (
+            <p className="text-body-s text-neutral-extra-dark">{description}</p>
+          ) : null}
+          {children}
+          {renderAction()}
+        </div>
+      ) : (
+        <p className="text-body-m text-neutral-extra-dark">{children}</p>
+      )}
+    </section>
+  );
 }

--- a/src/config/navItems.js
+++ b/src/config/navItems.js
@@ -1,0 +1,18 @@
+import { House, Search, MapPin, Calendar, User } from 'lucide-react';
+
+export const NAV_ITEMS = [
+  { label: 'Inicio', shortLabel: 'Inicio', path: '/inicio', icon: House },
+  { label: 'Buscar Aula', shortLabel: 'Buscar', path: '/buscar', icon: Search },
+  { label: 'Mapa', shortLabel: 'Mapa', path: '/mapa', icon: MapPin },
+  {
+    label: 'Mi Cursada',
+    shortLabel: 'Cursada',
+    path: '/cursada',
+    icon: Calendar,
+  },
+];
+
+export const NAV_ITEMS_MOBILE = [
+  ...NAV_ITEMS,
+  { label: 'Perfil', shortLabel: 'Perfil', path: '/perfil', icon: User },
+];

--- a/src/pages/Inicio/index.jsx
+++ b/src/pages/Inicio/index.jsx
@@ -1,166 +1,181 @@
-import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { Calendar, Map } from "lucide-react";
-import ActionCard from "../../components/Inicio/ActionCard/index.jsx";
-import BannerCambios from "../../components/Inicio/BannerCambios/index.jsx";
-import CardMateria from "../../components/Cursada/CardMateria/index.jsx";
-import CardProximaClase from "../../components/Inicio/CardProximaClase/index.jsx";
-import CtaCursada from "../../components/Inicio/CtaCursada/index.jsx";
-import HeroBusqueda from "../../components/Inicio/HeroBusqueda/index.jsx";
-import SaludoInicio from "../../components/Inicio/SaludoInicio/index.jsx";
-import SectionTitle from "../../components/Inicio/SectionTitle/index.jsx";
-import PantallaCarga from "../../components/PantallaCarga/index.jsx";
-import Tip from "../../components/Tip/index.jsx";
-import { useAuth } from "../../context/AuthContext";
-import { getMateriasPinneadasConHorarios } from "../../services/comisiones";
-import { buildInicioState } from "../../utils/inicio";
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { CalendarHeart, Map } from 'lucide-react';
+import ActionCard from '../../components/Inicio/ActionCard/index.jsx';
+import BannerCambios from '../../components/Inicio/BannerCambios/index.jsx';
+import CardMateria from '../../components/Cursada/CardMateria/index.jsx';
+import CardProximaClase from '../../components/Inicio/CardProximaClase/index.jsx';
+import CardSinClases from '../../components/Cursada/CardSinClases/index.jsx';
+import CtaCursada from '../../components/Inicio/CtaCursada/index.jsx';
+import HeroBusqueda from '../../components/Inicio/HeroBusqueda/index.jsx';
+import SaludoInicio from '../../components/Inicio/SaludoInicio/index.jsx';
+import SectionTitle from '../../components/Inicio/SectionTitle/index.jsx';
+import PantallaCarga from '../../components/PantallaCarga/index.jsx';
+import Tip from '../../components/Tip/index.jsx';
+import { useAuth } from '../../context/AuthContext';
+import { getMateriasPinneadasConHorarios } from '../../services/comisiones';
+import { buildInicioState } from '../../utils/inicio';
 
 const INICIO_STATE_INICIAL = {
-    usuario: { nombre: "estudiante" },
-    cambiosPendientes: { visible: false },
-    proximaClase: null,
-    programacionTitulo: "Programación del día",
-    programacion: [],
-    mostrarEstadoVacio: true,
+  usuario: { nombre: 'estudiante' },
+  cambiosPendientes: { visible: false },
+  proximaClase: null,
+  programacionTitulo: 'Programación del día',
+  programacion: [],
+  mostrarEstadoVacio: true,
 };
 
 export default function Inicio() {
-    const { user } = useAuth();
-    const navigate = useNavigate();
-    const [busquedaInicio, setBusquedaInicio] = useState("");
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState("");
-    const [inicioState, setInicioState] = useState(INICIO_STATE_INICIAL);
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const [busquedaInicio, setBusquedaInicio] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [inicioState, setInicioState] = useState(INICIO_STATE_INICIAL);
 
-    const irABuscar = (query = "") => {
-        const termino = query.trim();
-        navigate(termino ? `/buscar?q=${encodeURIComponent(termino)}` : "/buscar");
-    };
+  const irABuscar = (query = '') => {
+    const termino = query.trim();
+    navigate(termino ? `/buscar?q=${encodeURIComponent(termino)}` : '/buscar');
+  };
 
-    const abrirClase = (clase) => {
-        if (!clase.detalleAulaPath) {
-            navigate("/cursada");
-            return;
-        }
-
-        navigate(clase.detalleAulaPath, {
-            state: clase.detalleAulaState,
-        });
-    };
-
-    useEffect(() => {
-        if (!user) return;
-
-        let mounted = true;
-
-        getMateriasPinneadasConHorarios(user.id)
-            .then((materias) => {
-                if (!mounted) return;
-                setInicioState(buildInicioState({ user, materias }));
-            })
-            .catch((fetchError) => {
-                console.error(fetchError);
-                if (!mounted) return;
-                setError("No pudimos cargar tu inicio por ahora.");
-            })
-            .finally(() => {
-                if (mounted) setLoading(false);
-            });
-
-        return () => {
-            mounted = false;
-        };
-    }, [user]);
-
-    if (loading) {
-        return <PantallaCarga mensaje="Cargando inicio..." compact />;
+  const abrirClase = (clase) => {
+    if (!clase.detalleAulaPath) {
+      navigate('/cursada');
+      return;
     }
 
-    return (
-        <div className="min-h-full bg-base px-5 py-4 pb-28">
-            <div className="flex flex-col gap-7">
-                <SaludoInicio nombre={inicioState.usuario.nombre} />
+    navigate(clase.detalleAulaPath, {
+      state: clase.detalleAulaState,
+    });
+  };
 
-                {error ? (
-                    <div className="rounded-[20px] border border-error bg-state-red px-4 py-3">
-                        <p className="font-saira text-sm leading-4 text-neutral-extra-dark">
-                            {error}
-                        </p>
-                    </div>
-                ) : null}
+  useEffect(() => {
+    if (!user) return;
 
-                {inicioState.cambiosPendientes.visible ? (
-                    <BannerCambios onClick={() => navigate("/cursada")} />
-                ) : null}
+    let mounted = true;
 
-                {inicioState.mostrarEstadoVacio ? (
-                    <>
-                        <HeroBusqueda
-                            query={busquedaInicio}
-                            onChange={setBusquedaInicio}
-                            onClear={() => setBusquedaInicio("")}
-                            onSubmit={irABuscar}
-                        />
+    getMateriasPinneadasConHorarios(user.id)
+      .then((materias) => {
+        if (!mounted) return;
+        setInicioState(buildInicioState({ user, materias }));
+      })
+      .catch((fetchError) => {
+        console.error(fetchError);
+        if (!mounted) return;
+        setError('No pudimos cargar tu inicio por ahora.');
+      })
+      .finally(() => {
+        if (mounted) setLoading(false);
+      });
 
-                        <section className="space-y-3">
-                            <SectionTitle>Explorá el campus</SectionTitle>
-                            <div className="flex gap-4">
-                                <ActionCard
-                                    icon={Map}
-                                    titulo="Ver mapa"
-                                    detalle="Campus UNSAM"
-                                    onClick={() => navigate("/mapa")}
-                                />
-                                <ActionCard
-                                    icon={Calendar}
-                                    titulo="Mi cursada"
-                                    detalle="Calendario de clases"
-                                    onClick={() => navigate("/cursada")}
-                                />
-                            </div>
-                        </section>
+    return () => {
+      mounted = false;
+    };
+  }, [user]);
 
-                        <Tip>
-                            Pineá tus materias para recibir alertas cuando
-                            cambie tu aula.
-                        </Tip>
-                    </>
-                ) : (
-                    <>
-                        {inicioState.proximaClase ? (
-                            <section className="space-y-3">
-                                <SectionTitle>
-                                    {inicioState.proximaClase.tituloSeccion}
-                                </SectionTitle>
-                                <CardProximaClase
-                                    clase={inicioState.proximaClase}
-                                    onOpen={() => abrirClase(inicioState.proximaClase)}
-                                />
-                            </section>
-                        ) : null}
+  if (loading) {
+    return <PantallaCarga mensaje="Cargando inicio..." compact />;
+  }
 
-                        {inicioState.programacion.length > 0 ? (
-                            <section className="space-y-3">
-                                <SectionTitle>
-                                    {inicioState.programacionTitulo}
-                                </SectionTitle>
-                                <div className="space-y-2">
-                                    {inicioState.programacion.map((clase) => (
-                                        <CardMateria
-                                            key={clase.id}
-                                            clase={clase}
-                                            onOpen={() => abrirClase(clase)}
-                                        />
-                                    ))}
-                                </div>
-                                <CtaCursada
-                                    onClick={() => navigate("/cursada")}
-                                />
-                            </section>
-                        ) : null}
-                    </>
-                )}
+  return (
+    <div className="px-5 py-6 pb-28 lg:px-8 lg:pb-8">
+      <div className="flex flex-col gap-7">
+        <SaludoInicio nombre={inicioState.usuario.nombre} />
+
+        {error ? <Tip variant="error">{error}</Tip> : null}
+
+        {inicioState.cambiosPendientes.visible ? (
+          <BannerCambios onClick={() => navigate('/cursada')} />
+        ) : null}
+
+        {inicioState.mostrarEstadoVacio ? (
+          <div className="grid grid-cols-1 gap-7 xl:grid-cols-2 xl:items-start">
+            <HeroBusqueda
+              query={busquedaInicio}
+              onChange={setBusquedaInicio}
+              onClear={() => setBusquedaInicio('')}
+              onSubmit={irABuscar}
+            />
+
+            <div className="flex flex-col gap-4">
+              <section className="space-y-3">
+                <SectionTitle>Explorá el campus</SectionTitle>
+                <div className="flex gap-4">
+                  <ActionCard
+                    icon={Map}
+                    titulo="Ver mapa"
+                    detalle="Campus UNSAM"
+                    onClick={() => navigate('/mapa')}
+                  />
+                  <ActionCard
+                    icon={CalendarHeart}
+                    titulo="Mi cursada"
+                    detalle="Calendario de clases"
+                    onClick={() => navigate('/cursada')}
+                  />
+                </div>
+              </section>
+
+              <Tip>
+                Pineá tus materias para recibir alertas cuando cambie tu aula.
+              </Tip>
             </div>
-        </div>
-    );
+          </div>
+        ) : !inicioState.proximaClase &&
+          inicioState.programacion.length === 0 ? (
+          <CardSinClases
+            titulo="Sin clases hoy"
+            descripcion="No tenés clases programadas para hoy."
+          />
+        ) : (
+          <div className="grid grid-cols-1 gap-7 xl:grid-cols-2 xl:items-start">
+            <section className="space-y-3">
+              {inicioState.proximaClase ? (
+                <>
+                  <SectionTitle>
+                    {inicioState.proximaClase.tituloSeccion}
+                  </SectionTitle>
+                  <CardProximaClase
+                    clase={inicioState.proximaClase}
+                    onOpen={() => abrirClase(inicioState.proximaClase)}
+                  />
+                </>
+              ) : (
+                <>
+                  <SectionTitle>Próxima clase</SectionTitle>
+                  <CardSinClases
+                    titulo="Sin próxima clase"
+                    descripcion="No hay más clases programadas por hoy."
+                  />
+                </>
+              )}
+            </section>
+
+            <section className="space-y-3">
+              <SectionTitle>{inicioState.programacionTitulo}</SectionTitle>
+              {inicioState.programacion.length > 0 ? (
+                <>
+                  <div className="space-y-2">
+                    {inicioState.programacion.map((clase) => (
+                      <CardMateria
+                        key={clase.id}
+                        clase={clase}
+                        onOpen={() => abrirClase(clase)}
+                      />
+                    ))}
+                  </div>
+                  <CtaCursada onClick={() => navigate('/cursada')} />
+                </>
+              ) : (
+                <CardSinClases
+                  titulo="Sin clases hoy"
+                  descripcion="No tenés materias guardadas para este día."
+                />
+              )}
+            </section>
+          </div>
+        )}
+      </div>
+    </div>
+  );
 }

--- a/src/pages/Login/index.jsx
+++ b/src/pages/Login/index.jsx
@@ -123,18 +123,15 @@ export default function Login() {
           </div>
 
           {errors.form && (
-            <p className="font-saira text-sm text-error mt-3">{errors.form}</p>
+            <p className="text-body-s text-error mt-3">{errors.form}</p>
           )}
 
           <div className="flex flex-col gap-6 pt-16">
-            <BotonGoogle texto="Registrarme con Google" className="w-full" />
-            
+            <BotonGoogle texto="Iniciar con Google" className="w-full" />
 
             <div className="flex items-center gap-3">
               <div className="flex-1 h-px bg-neutral-main" />
-              <span className="font-saira font-semibold text-lg leading-8 text-neutral-dark">
-                o
-              </span>
+              <span className="text-title-m text-neutral-dark">o</span>
               <div className="flex-1 h-px bg-neutral-main" />
             </div>
 


### PR DESCRIPTION
#76 
- Se mueve SidebarNav al AppLayout (antes vivía en páginas individuales)
- Se crea src/config/navItems.js como única fuente de ítems de nav; Navbar y SidebarNav dejan de definirlos por separado
- Se elimina racha del Header mobile y del ProfileOverlay
- Se añade variante error al componente Tip; Inicio usa <Tip variant="error"> en lugar de div ad-hoc
- Se corrigen tokens tailwind: bg-[#001845]→bg-identity, font-saira text-sm→text-body-s/text-label-caption